### PR TITLE
Adds an extra step in setting up MFA for SSH

### DIFF
--- a/index.html
+++ b/index.html
@@ -205,7 +205,7 @@
     <p>You can SSH to the hosts with: <code>ssh &lt;host&gt;</code></p>
 
     <p><strong>NOTE:</strong> Make sure you have <a href="https://www.hw.ac.uk/uk/services/is/it-essentials/multi-factor-authentication.htm" target="_blank">MFA Enabled</a> as you will be required to enter a verification code too.</p>
-    <p>Make sure your authentication method is set to <b>Authentication phone</b> in your <a href="https://aka.ms/mfasetup">MFA Setup</a>.</p>
+    <p>Make sure your authentication method is set to <b>Mobile app</b> in your <a href="https://aka.ms/mfasetup">MFA Setup</a>.</p>
 
     <!-- MACS Help -->
     <div class="card-grid">

--- a/index.html
+++ b/index.html
@@ -205,6 +205,7 @@
     <p>You can SSH to the hosts with: <code>ssh &lt;host&gt;</code></p>
 
     <p><strong>NOTE:</strong> Make sure you have <a href="https://www.hw.ac.uk/uk/services/is/it-essentials/multi-factor-authentication.htm" target="_blank">MFA Enabled</a> as you will be required to enter a verification code too.</p>
+    <p>Make sure your authentication method is set to <b>Authentication phone</b> in your <a href="https://aka.ms/mfasetup">MFA Setup</a>.</p>
 
     <!-- MACS Help -->
     <div class="card-grid">


### PR DESCRIPTION
While setting up MFA for SSH access, the user needs to add the authentication code via their preferred Authenticator app (i.e. Microsoft Authenticator).

So this PR ensures that the user uses the Authenticator app instead of the other methods available (OTP via SMS, Office phone, etc.)