### PR TITLE
Accessibility changes in the Email Addresses

### DIFF
--- a/index.html
+++ b/index.html
@@ -286,7 +286,7 @@
 
     <footer>
       <center>
-        <p>This website is unaffiliated with <a style="color: #EEE" href="https://hw.ac.uk">Heriot-Watt University</a> or the <a style="color: #EEE;" href="https://www.hwunion.com/">Student Union</a>.</p>
+        <p>This website is unaffiliated with <a class="inlineLink" style="color: #EEE" href="https://hw.ac.uk" target="_blank">Heriot-Watt University</a> or the <a class="inlineLink" style="color: #EEE;" href="https://www.hwunion.com/" target="_blank">Student Union</a>.</p>
         <p>Contribute to this site on <a class="inlineLink" href="https://github.com/hw-cs-reps/myhwu" rel="noreferrer noopener" target="_blank">GitHub</a>!</p>
       </center>
     </footer>

--- a/index.html
+++ b/index.html
@@ -237,7 +237,7 @@
       <!-- Student Centre -->
       <a class="card" href="mailto:studentcentre@hw.ac.uk">
         <p class="card-title">Student Centre</p>
-        <p class="card-text">studentcentre@hw.ac.uk</p>
+        <p class="card-text">StudentCentre@hw.ac.uk</p>
       </a>
 
       <!-- Disability -->
@@ -249,19 +249,19 @@
       <!-- Student Wellbeing -->
       <a class="card" href="mailto:studentwellbeing@hw.ac.uk">
         <p class="card-title">Student Wellbeing</p>
-        <p class="card-text">studentwellbeing@hw.ac.uk</p>
+        <p class="card-text">StudentWellbeing@hw.ac.uk</p>
       </a>
 
       <!-- Info Services Helpdesk -->
       <a class="card" href="mailto:ishelp@hw.ac.uk">
         <p class="card-title">Info Services Helpdesk</p>
-        <p class="card-text">ishelp@hw.ac.uk</p>
+        <p class="card-text">ISHelp@hw.ac.uk</p>
       </a>
 
       <!-- IT Helpdesk -->
       <a class="card" href="mailto:ithelp@hw.ac.uk">
         <p class="card-title">IT Helpdesk</p>
-        <p class="card-text">ithelp@hw.ac.uk</p>
+        <p class="card-text">ITHelp@hw.ac.uk</p>
       </a>
 
       <!-- Halls -->
@@ -273,13 +273,13 @@
       <!-- Residence Life -->
       <a class="card" href="mailto:reslife@hw.ac.uk">
         <p class="card-title">Residence Life</p>
-        <p class="card-text">reslife@hw.ac.uk</p>
+        <p class="card-text">ResLife@hw.ac.uk</p>
       </a>
 
       <!-- Off Campus Services -->
       <a class="card" href="mailto:offcampus@hw.ac.uk">
         <p class="card-title">Off Campus Services</p>
-        <p class="card-text">offcampus@hw.ac.uk</p>
+        <p class="card-text">OffCampus@hw.ac.uk</p>
       </a>
     </div>
     <br>

--- a/index.html
+++ b/index.html
@@ -286,7 +286,7 @@
 
     <footer>
       <center>
-        <p>This website is unaffiliated with Heriot-Watt University or the Student Union.</p>
+        <p>This website is unaffiliated with <a style="color: #EEE" href="https://hw.ac.uk">Heriot-Watt University</a> or the <a style="color: #EEE;" href="https://www.hwunion.com/">Student Union</a>.</p>
         <p>Contribute to this site on <a class="inlineLink" href="https://github.com/hw-cs-reps/myhwu" rel="noreferrer noopener" target="_blank">GitHub</a>!</p>
       </center>
     </footer>


### PR DESCRIPTION
Uses camelCase styling for email addresses with multiple words (i.e. `StudentWellbeing` instead of `studentwellbeing`) to make it more accessible and quicker to read when the user comes across the list.

Also adds links in the bottom for the [HWU website](https://www.hw.ac.uk/) and the [Student Union](https://www.hwunion.com/) in the footer.