### PR TITLE
Updates Teaching Timetable Link

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,13 +50,10 @@
       </a>
 
       <!-- Teaching Timetables -->
-      <div class="card">
-        <div class="card-title">Teaching Timetables</div>
-        <div class="card-grid sub-card">
-          <a class="left" href="https://timetable.hw.ac.uk/WebTimetables/LiveED/login.aspx">Edinburgh</a>
-          <a class="right" href="https://timetable.hw.ac.uk/WebTimetables/LiveDU/login.aspx">Dubai</a>
-        </div>
-      </div>
+      <a class="card" href="https://timetableexplorer.hw.ac.uk/">
+        <p class="card-title">Teaching Timetables</p>
+        <p class="card-text">timetableexplorer.hw.ac.uk</p>
+      </a>
 
       <!-- Resource Booker -->
       <div class="card">


### PR DESCRIPTION
From this AY (24-25), HWU will be switching over to a new [Teaching Timetables](https://timetableexplorer.hw.ac.uk/). 

This PR makes the webpage up to date with the new links! 

For Reference: https://www.hw.ac.uk/uk/students/studies/timetables.htm