### PR TITLE
Removes the legacy MACS Project System

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,10 +109,6 @@
     <p class="card-title">MACS Project System</p>
     <a href="https://projects.hw.ac.uk/" class="link-list" rel="noreferrer noopener" target="_self">projects.hw.ac.uk</a>
 
-    <!-- Legacy MACS Project System -->
-    <p class="card-title">Old MACS Project System (2022)</p>
-    <a href="https://www.macs.hw.ac.uk/cs/project-system/" class="link-list" rel="noreferrer noopener" target="_self">macs.hw.ac.uk/cs/project-system</a>
-
     <!-- Exam Links -->
     <div>
       <a href="#exam" class="h h2">


### PR DESCRIPTION
This PR removes the [legacy MACS Project System](https://www.macs.hw.ac.uk/cs/project-system) on the portal, since it is no longer accessible, and now throws the error as shown in the below screenshot:

<img width="1246" height="364" alt="image" src="https://github.com/user-attachments/assets/ffc08f5a-e545-468c-adba-72ea1f1f0127" />